### PR TITLE
9 member service implementation

### DIFF
--- a/src/main/java/com/sk/growthnav/GrowthNavApplication.java
+++ b/src/main/java/com/sk/growthnav/GrowthNavApplication.java
@@ -1,15 +1,23 @@
 package com.sk.growthnav;
 
+import com.sk.growthnav.api.conversation.repository.ConversationRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @EnableJpaAuditing
-@SpringBootApplication
 @EnableMongoAuditing
 @EnableMongoRepositories(basePackages = "com.sk.growthnav.api.conversation.repository")
+@EnableJpaRepositories(excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        value = {ConversationRepository.class}
+))
+@SpringBootApplication
 public class GrowthNavApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sk/growthnav/api/project/dto/ProjectInfoDTO.java
+++ b/src/main/java/com/sk/growthnav/api/project/dto/ProjectInfoDTO.java
@@ -1,0 +1,44 @@
+package com.sk.growthnav.api.project.dto;
+
+import com.sk.growthnav.api.project.entity.Project;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ProjectInfoDTO {
+    Long projectId;
+    String projectName;
+    String role;
+    String domain;
+    String scale;
+    String startDate;
+    String endDate;
+    List<String> skills;
+
+    // 날짜 포맷터 (ISO 형식: "2023-01-15")
+    static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    // Entity -> DTO 변환
+    public static ProjectInfoDTO from(Project project, List<String> skills) {
+        return ProjectInfoDTO.builder()
+                .projectId(project.getId())
+                .projectName(project.getName())
+                .role(project.getUserRole())
+                .domain(project.getDomain())
+                .scale(project.getProjectScale().getLabel())
+                .startDate(project.getStartDate() != null ?
+                        project.getStartDate().format(DATE_FORMATTER) : null)
+                .endDate(project.getEndDate() != null ?
+                        project.getEndDate().format(DATE_FORMATTER) : null)
+                .skills(skills)
+                .build();
+
+    }
+}

--- a/src/main/java/com/sk/growthnav/api/project/repository/ProjectRepository.java
+++ b/src/main/java/com/sk/growthnav/api/project/repository/ProjectRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
-    List<Project> findByUserId(Long userId);
+    List<Project> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/sk/growthnav/api/project/service/ProjectService.java
+++ b/src/main/java/com/sk/growthnav/api/project/service/ProjectService.java
@@ -1,0 +1,76 @@
+package com.sk.growthnav.api.project.service;
+
+import com.sk.growthnav.api.project.dto.ProjectInfoDTO;
+import com.sk.growthnav.api.project.entity.Project;
+import com.sk.growthnav.api.project.repository.ProjectRepository;
+import com.sk.growthnav.api.skill.service.SkillService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final SkillService skillService;
+
+    /**
+     * 회원의 모든 프로젝트 조회
+     *
+     * @param memberId
+     * @return
+     */
+    public List<Project> findByMemberId(Long memberId) {
+        return projectRepository.findByMemberId(memberId);
+    }
+
+    /**
+     * 회원의 프로젝트 정보를 DTO로 변환하여 조회
+     * FastAPI 연동용 데이터 구조
+     *
+     * @param memberId
+     * @return
+     */
+    public List<ProjectInfoDTO> getProjectsByMember(Long memberId) {
+        List<Project> projects = findByMemberId(memberId);
+
+        log.info("회원 {}의 프로젝트 {}개 조회됨.", memberId, projects.size());
+
+        return projects.stream()
+                .map(project -> {
+                    List<String> skills = skillService.getSkillNamesByProject(project.getId());
+                    log.debug("프로젝트 {}의 스킬 {}개: {}", project.getId(), skills.size(), skills);
+
+                    return ProjectInfoDTO.from(project, skills);
+                })
+                .toList();
+    }
+
+    /**
+     * 프로젝트 ID로 단일 프로젝트 조회
+     */
+    public Project findById(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("프로젝트를 찾을 수 없습니다: " + projectId));
+    }
+
+    /**
+     * 회원의 프로젝트 개수 조회
+     */
+    public int getProjectCountByMember(Long memberId) {
+        return findByMemberId(memberId).size();
+    }
+
+    /**
+     * 회원이 프로젝트를 가지고 있는지 확인
+     */
+    public boolean hasProjects(Long memberId) {
+        return !findByMemberId(memberId).isEmpty();
+    }
+}

--- a/src/main/java/com/sk/growthnav/api/skill/dto/SkillInfoDTO.java
+++ b/src/main/java/com/sk/growthnav/api/skill/dto/SkillInfoDTO.java
@@ -1,0 +1,25 @@
+package com.sk.growthnav.api.skill.dto;
+
+import com.sk.growthnav.api.skill.entity.Skill;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SkillInfoDTO {
+
+    Long skillId;
+    String skillName;
+    Long projectId;
+
+    public static SkillInfoDTO from(Skill skill) {
+        return SkillInfoDTO.builder()
+                .skillId(skill.getId())
+                .skillName(skill.getName())
+                .projectId(skill.getProject().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/sk/growthnav/api/skill/entity/Skill.java
+++ b/src/main/java/com/sk/growthnav/api/skill/entity/Skill.java
@@ -15,7 +15,7 @@ public class Skill extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "skill_id", unique = true)
-    private String id;
+    private Long id;
 
     @Column(length = 50, name = "skill_name")
     private String name;

--- a/src/main/java/com/sk/growthnav/api/skill/repository/SkillRepository.java
+++ b/src/main/java/com/sk/growthnav/api/skill/repository/SkillRepository.java
@@ -3,8 +3,40 @@ package com.sk.growthnav.api.skill.repository;
 import com.sk.growthnav.api.skill.entity.Skill;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SkillRepository extends JpaRepository<Skill, Long> {
+    /**
+     * 프로젝트 ID로 모든 스킬 소회
+     * 1개 프로젝트에 여러 스킬이 있을 수 있으므로 List 반환
+     *
+     * @param projectId
+     * @return
+     */
+    List<Skill> findAllByProjectId(Long projectId);
+
+    /**
+     * Project ID로 첫 번째 스킬 조회 (하위 호환성을 위해 유지)
+     *
+     * @param projectId
+     * @return
+     */
     Optional<Skill> findByProjectId(Long projectId);
+
+    /**
+     * 프로젝트 ID로 스킬 존재 여부 확인
+     *
+     * @param projectId
+     * @return
+     */
+    boolean existsByProjectId(Long projectId);
+
+    /**
+     * 스킬 명으로 검색 (부분 일치)
+     *
+     * @param skillName
+     * @return
+     */
+    List<Skill> findByNameContainingIgnoreCase(String skillName);
 }

--- a/src/main/java/com/sk/growthnav/api/skill/service/SkillService.java
+++ b/src/main/java/com/sk/growthnav/api/skill/service/SkillService.java
@@ -1,0 +1,61 @@
+package com.sk.growthnav.api.skill.service;
+
+import com.sk.growthnav.api.skill.dto.SkillInfoDTO;
+import com.sk.growthnav.api.skill.entity.Skill;
+import com.sk.growthnav.api.skill.repository.SkillRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class SkillService {
+
+    private final SkillRepository skillRepository;
+
+    /**
+     * 프로젝트 모든 스킬 이름 조회
+     *
+     * @param projectId
+     * @return
+     */
+    public List<String> getSkillNamesByProject(Long projectId) {
+        List<Skill> skills = skillRepository.findAllByProjectId(projectId);
+        return skills.stream()
+                .map(Skill::getName)
+                .toList();
+    }
+
+    /**
+     * 프로젝트의 모든 스킬 DTO 조회
+     *
+     * @param projectId
+     * @return
+     */
+    public List<SkillInfoDTO> getSkillsByProject(Long projectId) {
+        List<Skill> skills = skillRepository.findAllByProjectId(projectId);
+        return skills.stream()
+                .map(SkillInfoDTO::from)
+                .toList();
+    }
+
+    /**
+     * 스킬 ID로 단일 스킬 조회
+     */
+    public Skill findById(Long skillId) {
+        return skillRepository.findById(skillId)
+                .orElseThrow(() -> new RuntimeException("스킬을 찾을 수 없습니다: " + skillId));
+    }
+
+    /**
+     * 프로젝트에 스킬이 있는지 확인
+     */
+    public boolean hasSkills(Long projectId) {
+        return skillRepository.existsByProjectId(projectId);
+    }
+}

--- a/src/test/java/com/sk/growthnav/api/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/sk/growthnav/api/project/service/ProjectServiceTest.java
@@ -1,0 +1,258 @@
+package com.sk.growthnav.api.project.service;
+
+import com.sk.growthnav.api.member.entity.Member;
+import com.sk.growthnav.api.project.dto.ProjectInfoDTO;
+import com.sk.growthnav.api.project.entity.Project;
+import com.sk.growthnav.api.project.entity.ProjectScale;
+import com.sk.growthnav.api.project.repository.ProjectRepository;
+import com.sk.growthnav.api.skill.service.SkillService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProjectService 테스트")
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private SkillService skillService;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @Test
+    @DisplayName("회원의 모든 프로젝트 조회 성공")
+    void findByMemberId_Success() {
+        // Given
+        Long memberId = 1L;
+        List<Project> mockProjects = createMockProjects(memberId);
+
+        given(projectRepository.findByMemberId(memberId))
+                .willReturn(mockProjects);
+
+        // When
+        List<Project> result = projectService.findByMemberId(memberId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("스마트팩토리 구축");
+        assertThat(result.get(1).getName()).isEqualTo("ERP 시스템 개선");
+
+        then(projectRepository).should(times(1)).findByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("회원에게 프로젝트가 없는 경우 빈 리스트 반환")
+    void findByMemberId_EmptyList() {
+        // Given
+        Long memberId = 999L;
+        given(projectRepository.findByMemberId(memberId))
+                .willReturn(List.of());
+
+        // When
+        List<Project> result = projectService.findByMemberId(memberId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        then(projectRepository).should(times(1)).findByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("회원의 프로젝트 정보를 DTO로 변환하여 조회 성공")
+    void getProjectsByMember_Success() {
+        // Given
+        Long memberId = 1L;
+        List<Project> mockProjects = createMockProjects(memberId);
+
+        given(projectRepository.findByMemberId(memberId))
+                .willReturn(mockProjects);
+
+        // 각 프로젝트별 스킬 Mock 설정
+        given(skillService.getSkillNamesByProject(1L))
+                .willReturn(Arrays.asList("Java", "Spring Boot", "PostgreSQL"));
+        given(skillService.getSkillNamesByProject(2L))
+                .willReturn(Arrays.asList("Python", "Django"));
+
+        // When
+        List<ProjectInfoDTO> result = projectService.getProjectsByMember(memberId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+
+        // 첫 번째 프로젝트 검증
+        ProjectInfoDTO firstProject = result.get(0);
+        assertThat(firstProject.getProjectName()).isEqualTo("스마트팩토리 구축");
+        assertThat(firstProject.getRole()).isEqualTo("Backend Developer");
+        assertThat(firstProject.getDomain()).isEqualTo("제조");
+        assertThat(firstProject.getScale()).isEqualTo("대");
+        assertThat(firstProject.getStartDate()).isEqualTo("2023-01-15");
+        assertThat(firstProject.getEndDate()).isEqualTo("2023-12-31");
+        assertThat(firstProject.getSkills()).containsExactly("Java", "Spring Boot", "PostgreSQL");
+
+        // 두 번째 프로젝트 검증
+        ProjectInfoDTO secondProject = result.get(1);
+        assertThat(secondProject.getProjectName()).isEqualTo("ERP 시스템 개선");
+        assertThat(secondProject.getRole()).isEqualTo("Application PM");
+        assertThat(secondProject.getDomain()).isEqualTo("금융");
+        assertThat(secondProject.getScale()).isEqualTo("중");
+        assertThat(secondProject.getStartDate()).isEqualTo("2024-03-01");
+        assertThat(secondProject.getEndDate()).isNull(); // 진행중인 프로젝트
+        assertThat(secondProject.getSkills()).containsExactly("Python", "Django");
+
+        then(projectRepository).should(times(1)).findByMemberId(memberId);
+        then(skillService).should(times(1)).getSkillNamesByProject(1L);
+        then(skillService).should(times(1)).getSkillNamesByProject(2L);
+    }
+
+    @Test
+    @DisplayName("프로젝트 ID로 단일 프로젝트 조회 성공")
+    void findById_Success() {
+        // Given
+        Long projectId = 1L;
+        Project mockProject = createMockProject(1L, "스마트팩토리 구축", 1L);
+
+        given(projectRepository.findById(projectId))
+                .willReturn(Optional.of(mockProject));
+
+        // When
+        Project result = projectService.findById(projectId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(projectId);
+        assertThat(result.getName()).isEqualTo("스마트팩토리 구축");
+
+        then(projectRepository).should(times(1)).findById(projectId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 프로젝트 ID로 조회 시 예외 발생")
+    void findById_ProjectNotFound() {
+        // Given
+        Long nonExistentId = 999L;
+        given(projectRepository.findById(nonExistentId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> projectService.findById(nonExistentId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("프로젝트를 찾을 수 없습니다: " + nonExistentId);
+
+        then(projectRepository).should(times(1)).findById(nonExistentId);
+    }
+
+    @Test
+    @DisplayName("회원의 프로젝트 개수 조회 성공")
+    void getProjectCountByMember_Success() {
+        // Given
+        Long memberId = 1L;
+        List<Project> mockProjects = createMockProjects(memberId);
+
+        given(projectRepository.findByMemberId(memberId))
+                .willReturn(mockProjects);
+
+        // When
+        int result = projectService.getProjectCountByMember(memberId);
+
+        // Then
+        assertThat(result).isEqualTo(2);
+        then(projectRepository).should(times(1)).findByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("회원이 프로젝트를 가지고 있는지 확인 - 있는 경우")
+    void hasProjects_True() {
+        // Given
+        Long memberId = 1L;
+        List<Project> mockProjects = createMockProjects(memberId);
+
+        given(projectRepository.findByMemberId(memberId))
+                .willReturn(mockProjects);
+
+        // When
+        boolean result = projectService.hasProjects(memberId);
+
+        // Then
+        assertThat(result).isTrue();
+        then(projectRepository).should(times(1)).findByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("회원이 프로젝트를 가지고 있는지 확인 - 없는 경우")
+    void hasProjects_False() {
+        // Given
+        Long memberId = 999L;
+        given(projectRepository.findByMemberId(memberId))
+                .willReturn(List.of());
+
+        // When
+        boolean result = projectService.hasProjects(memberId);
+
+        // Then
+        assertThat(result).isFalse();
+        then(projectRepository).should(times(1)).findByMemberId(memberId);
+    }
+
+    // === Helper Methods ===
+
+    private List<Project> createMockProjects(Long memberId) {
+        Member mockMember = new Member(memberId, "오현진", "password", "test@example.com");
+
+        return Arrays.asList(
+                new Project(
+                        1L,
+                        "스마트팩토리 구축",
+                        "Backend Developer",
+                        "제조",
+                        ProjectScale.LARGE,
+                        LocalDateTime.of(2023, 1, 15, 0, 0),
+                        LocalDateTime.of(2023, 12, 31, 0, 0),
+                        mockMember
+                ),
+                new Project(
+                        2L,
+                        "ERP 시스템 개선",
+                        "Application PM",
+                        "금융",
+                        ProjectScale.MEDIUM,
+                        LocalDateTime.of(2024, 3, 1, 0, 0),
+                        null, // 진행중인 프로젝트
+                        mockMember
+                )
+        );
+    }
+
+    private Project createMockProject(Long id, String name, Long memberId) {
+        Member mockMember = new Member(memberId, "테스트 사용자", "password", "test@example.com");
+
+        return new Project(
+                id,
+                name,
+                "Backend Developer",
+                "IT",
+                ProjectScale.LARGE,
+                LocalDateTime.of(2023, 1, 15, 0, 0),
+                LocalDateTime.of(2023, 12, 31, 0, 0),
+                mockMember
+        );
+    }
+}

--- a/src/test/java/com/sk/growthnav/api/skill/service/SkillServiceTest.java
+++ b/src/test/java/com/sk/growthnav/api/skill/service/SkillServiceTest.java
@@ -1,0 +1,199 @@
+package com.sk.growthnav.api.skill.service;
+
+import com.sk.growthnav.api.project.entity.Project;
+import com.sk.growthnav.api.project.entity.ProjectScale;
+import com.sk.growthnav.api.skill.dto.SkillInfoDTO;
+import com.sk.growthnav.api.skill.entity.Skill;
+import com.sk.growthnav.api.skill.repository.SkillRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SkillService 테스트")
+class SkillServiceTest {
+
+    @Mock
+    private SkillRepository skillRepository;
+
+    @InjectMocks
+    private SkillService skillService;
+
+    @Test
+    @DisplayName("프로젝트의 모든 스킬 이름 조회 성공")
+    void getSkillNamesByProject_Success() {
+        // Given
+        Long projectId = 1L;
+        Project mockProject = createMockProject(projectId, "테스트 프로젝트");
+
+        List<Skill> mockSkills = Arrays.asList(
+                createMockSkill(1L, "Java", mockProject),
+                createMockSkill(2L, "Spring Boot", mockProject),
+                createMockSkill(3L, "PostgreSQL", mockProject)
+        );
+
+        given(skillRepository.findAllByProjectId(projectId))
+                .willReturn(mockSkills);
+
+        // When
+        List<String> result = skillService.getSkillNamesByProject(projectId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly("Java", "Spring Boot", "PostgreSQL");
+
+        then(skillRepository).should(times(1)).findAllByProjectId(projectId);
+    }
+
+    @Test
+    @DisplayName("프로젝트에 스킬이 없는 경우 빈 리스트 반환")
+    void getSkillNamesByProject_EmptyList() {
+        // Given
+        Long projectId = 999L;
+        given(skillRepository.findAllByProjectId(projectId))
+                .willReturn(List.of());
+
+        // When
+        List<String> result = skillService.getSkillNamesByProject(projectId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        then(skillRepository).should(times(1)).findAllByProjectId(projectId);
+    }
+
+    @Test
+    @DisplayName("프로젝트의 모든 스킬 DTO 조회 성공")
+    void getSkillsByProject_Success() {
+        // Given
+        Long projectId = 1L;
+        Project mockProject = createMockProject(projectId, "테스트 프로젝트");
+
+        List<Skill> mockSkills = Arrays.asList(
+                createMockSkill(1L, "Java", mockProject),
+                createMockSkill(2L, "Spring Boot", mockProject)
+        );
+
+        given(skillRepository.findAllByProjectId(projectId))
+                .willReturn(mockSkills);
+
+        // When
+        List<SkillInfoDTO> result = skillService.getSkillsByProject(projectId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getSkillName()).isEqualTo("Java");
+        assertThat(result.get(0).getProjectId()).isEqualTo(projectId);
+        assertThat(result.get(1).getSkillName()).isEqualTo("Spring Boot");
+
+        then(skillRepository).should(times(1)).findAllByProjectId(projectId);
+    }
+
+    @Test
+    @DisplayName("스킬 ID로 단일 스킬 조회 성공")
+    void findById_Success() {
+        // Given
+        Long skillId = 1L;
+        Project mockProject = createMockProject(1L, "테스트 프로젝트");
+        Skill mockSkill = createMockSkill(skillId, "Java", mockProject);
+
+        given(skillRepository.findById(skillId))
+                .willReturn(Optional.of(mockSkill));
+
+        // When
+        Skill result = skillService.findById(skillId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(skillId);
+        assertThat(result.getName()).isEqualTo("Java");
+
+        then(skillRepository).should(times(1)).findById(skillId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 스킬 ID로 조회 시 예외 발생")
+    void findById_SkillNotFound() {
+        // Given
+        Long nonExistentId = 999L;
+        given(skillRepository.findById(nonExistentId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> skillService.findById(nonExistentId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("스킬을 찾을 수 없습니다: " + nonExistentId);
+
+        then(skillRepository).should(times(1)).findById(nonExistentId);
+    }
+
+    @Test
+    @DisplayName("프로젝트에 스킬이 있는지 확인 - 있는 경우")
+    void hasSkills_True() {
+        // Given
+        Long projectId = 1L;
+        given(skillRepository.existsByProjectId(projectId))
+                .willReturn(true);
+
+        // When
+        boolean result = skillService.hasSkills(projectId);
+
+        // Then
+        assertThat(result).isTrue();
+        then(skillRepository).should(times(1)).existsByProjectId(projectId);
+    }
+
+    @Test
+    @DisplayName("프로젝트에 스킬이 있는지 확인 - 없는 경우")
+    void hasSkills_False() {
+        // Given
+        Long projectId = 999L;
+        given(skillRepository.existsByProjectId(projectId))
+                .willReturn(false);
+
+        // When
+        boolean result = skillService.hasSkills(projectId);
+
+        // Then
+        assertThat(result).isFalse();
+        then(skillRepository).should(times(1)).existsByProjectId(projectId);
+    }
+
+    // === Helper Methods ===
+
+    private Project createMockProject(Long id, String name) {
+        return new Project(
+                id,
+                name,
+                "Backend Developer",
+                "IT",
+                ProjectScale.LARGE,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusMonths(6),
+                null  // Member는 null로 설정
+        );
+    }
+
+    private Skill createMockSkill(Long id, String name, Project project) {
+        return Skill.builder()
+                .id(id)
+                .name(name)
+                .project(project)
+                .build();
+    }
+}


### PR DESCRIPTION
- SkillRepository Long ID로 수정 및 메서드 추가 (findAllByProjectId)
- SkillService 구현 (getSkillNamesByProject, getSkillsByProject 등)
- SkillInfoDTO 구현 및 Entity 변환 로직
- ProjectService 구현 (getProjectsByMember, SkillService 의존성 주입)
- ProjectInfoDTO 구현 및 날짜 포맷팅 적용
- SkillServiceTest, ProjectServiceTest 단위 테스트 구현
- Service 간 의존성 주입 및 Mock 테스트 완료

close #11 